### PR TITLE
from_slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,21 @@ impl<T> NonEmpty<T> {
         self.1.truncate(len - 1);
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator + 'a {
+    /// ```
+    /// use nonempty::NonEmpty;
+    ///
+    /// let mut l = NonEmpty::new(42);
+    /// l.push(36);
+    /// l.push(58);
+    ///
+    /// let mut l_iter = l.iter();
+    ///
+    /// assert_eq!(l_iter.next(), Some(&42));
+    /// assert_eq!(l_iter.next(), Some(&36));
+    /// assert_eq!(l_iter.next(), Some(&58));
+    /// assert_eq!(l_iter.next(), None);
+    /// ```
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &T> + 'a {
         std::iter::once(&self.0).chain(self.1.iter())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ impl<T> NonEmpty<T> {
     }
 
     /// Often we have a `Vec` (or slice `&[T]`) but want to ensure that it is `NonEmpty` before
-    /// proceeding with a computation. Using `from_vec` will give us a proof
+    /// proceeding with a computation. Using `from_slice` will give us a proof
     /// that we have a `NonEmpty` in the `Some` branch, otherwise it allows
     /// the caller to handle the `None` case.
     ///
@@ -122,14 +122,14 @@ impl<T> NonEmpty<T> {
     /// ```
     /// use nonempty::NonEmpty;
     ///
-    /// let non_empty_vec = NonEmpty::from_vec(&[1, 2, 3, 4, 5]);
+    /// let non_empty_vec = NonEmpty::from_slice(&[1, 2, 3, 4, 5]);
     /// assert!(non_empty_vec.is_some());
     ///
-    /// let empty_vec: Option<NonEmpty<&u32>> = NonEmpty::from_vec(&[]);
+    /// let empty_vec: Option<NonEmpty<&u32>> = NonEmpty::from_slice(&[]);
     /// assert!(empty_vec.is_none());
     /// ```
-    pub fn from_vec(vec: &[T]) -> Option<NonEmpty<&T>> {
-        let split = vec.split_first();
+    pub fn from_slice(slice: &[T]) -> Option<NonEmpty<&T>> {
+        let split = slice.split_first();
         match split {
             Some((h, t)) => {
                 let mut result: NonEmpty<&T> = NonEmpty::new(h);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl<T> NonEmpty<T> {
         std::iter::once(&self.0).chain(self.1.iter())
     }
 
-    /// Often we have a `Vec` but want to ensure that it is `NonEmpty` before
+    /// Often we have a `Vec` (or slice `&[T]`) but want to ensure that it is `NonEmpty` before
     /// proceeding with a computation. Using `from_vec` will give us a proof
     /// that we have a `NonEmpty` in the `Some` branch, otherwise it allows
     /// the caller to handle the `None` case.
@@ -122,21 +122,18 @@ impl<T> NonEmpty<T> {
     /// ```
     /// use nonempty::NonEmpty;
     ///
-    /// let non_empty_vec = NonEmpty::from_vec(vec!([1, 2, 3, 4, 5]));
+    /// let non_empty_vec = NonEmpty::from_vec(&[1, 2, 3, 4, 5]);
     /// assert!(non_empty_vec.is_some());
     ///
-    /// let empty_vec: Option<NonEmpty<u32>> = NonEmpty::from_vec(Vec::new());
+    /// let empty_vec: Option<NonEmpty<&u32>> = NonEmpty::from_vec(&[]);
     /// assert!(empty_vec.is_none());
     /// ```
-    pub fn from_vec(vec: Vec<T>) -> Option<NonEmpty<T>> {
-        let mut vec = vec;
-        let head = vec.pop();
-        match head {
-            Some(t) => {
-                let mut result = NonEmpty::new(t);
-                for u in vec {
-                    result.push(u)
-                }
+    pub fn from_vec(vec: &[T]) -> Option<NonEmpty<&T>> {
+        let split = vec.split_first();
+        match split {
+            Some((h, t)) => {
+                let mut result: NonEmpty<&T> = NonEmpty::new(h);
+                t.iter().for_each(|u| result.push(u));
                 Some(result)
             }
             None => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,11 +132,9 @@ impl<T> NonEmpty<T> {
     where
         T: Clone,
     {
-        let split = slice.split_first();
-        match split {
-            Some((h, t)) => Some(NonEmpty(h.clone(), t.into())),
-            None => None,
-        }
+        slice
+            .split_first()
+            .map(|(h, t)| NonEmpty(h.clone(), t.into()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,11 @@
 pub struct NonEmpty<T>(T, Vec<T>);
 
 impl<T> NonEmpty<T> {
-    pub fn new(e: T) -> Self {
+    pub const fn new(e: T) -> Self {
         Self::singleton(e)
     }
 
-    pub fn singleton(e: T) -> Self {
+    pub const fn singleton(e: T) -> Self {
         NonEmpty(e, Vec::new())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,14 +128,13 @@ impl<T> NonEmpty<T> {
     /// let empty_vec: Option<NonEmpty<&u32>> = NonEmpty::from_slice(&[]);
     /// assert!(empty_vec.is_none());
     /// ```
-    pub fn from_slice(slice: &[T]) -> Option<NonEmpty<&T>> {
+    pub fn from_slice(slice: &[T]) -> Option<NonEmpty<T>>
+    where
+        T: Clone,
+    {
         let split = slice.split_first();
         match split {
-            Some((h, t)) => {
-                let mut result: NonEmpty<&T> = NonEmpty::new(h);
-                t.iter().for_each(|u| result.push(u));
-                Some(result)
-            }
+            Some((h, t)) => Some(NonEmpty(h.clone(), t.into())),
             None => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,37 @@ impl<T> NonEmpty<T> {
     pub fn iter<'a>(&'a self) -> impl Iterator<Item = &T> + 'a {
         std::iter::once(&self.0).chain(self.1.iter())
     }
+
+    /// Often we have a `Vec` but want to ensure that it is `NonEmpty` before
+    /// proceeding with a computation. Using `from_vec` will give us a proof
+    /// that we have a `NonEmpty` in the `Some` branch, otherwise it allows
+    /// the caller to handle the `None` case.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty::NonEmpty;
+    ///
+    /// let non_empty_vec = NonEmpty::from_vec(vec!([1, 2, 3, 4, 5]));
+    /// assert!(non_empty_vec.is_some());
+    ///
+    /// let empty_vec: Option<NonEmpty<u32>> = NonEmpty::from_vec(Vec::new());
+    /// assert!(empty_vec.is_none());
+    /// ```
+    pub fn from_vec(vec: Vec<T>) -> Option<NonEmpty<T>> {
+        let mut vec = vec;
+        let head = vec.pop();
+        match head {
+            Some(t) => {
+                let mut result = NonEmpty::new(t);
+                for u in vec {
+                    result.push(u)
+                }
+                Some(result)
+            }
+            None => None,
+        }
+    }
 }
 
 impl<T> Into<Vec<T>> for NonEmpty<T> {


### PR DESCRIPTION
Add `from_slice` to allow callers to get a `NonEmpty` from a `&[T]` (maybe)