### PR TITLE
Binary Search and Insert

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! assert_eq!(v, vec![42, 36, 58, 9001]);
 //! ```
 use std::cmp::Ordering;
+use std::mem;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NonEmpty<T>(T, Vec<T>);
@@ -73,24 +74,18 @@ impl<T> NonEmpty<T> {
     /// assert_eq!(non_empty, NonEmpty::from((1, vec![4, 2, 3])));
     /// non_empty.insert(4, 5);
     /// assert_eq!(non_empty, NonEmpty::from((1, vec![4, 2, 3, 5])));
+    /// non_empty.insert(0, 42);
+    /// assert_eq!(non_empty, NonEmpty::from((42, vec![1, 4, 2, 3, 5])));
     /// ```
-    pub fn insert(&mut self, index: usize, element: T)
-    where
-        T: Clone,
-    {
+    pub fn insert(&mut self, index: usize, element: T) {
         let len = self.len();
         assert!(index <= len);
 
         if index == 0 {
-            let head = self.0.clone();
-            let tail = &mut self.1;
-            tail.insert(0, head);
-            self.0 = element;
-            self.1 = tail.clone();
+            let head = mem::replace(&mut self.0, element);
+            self.1.insert(0, head);
         } else {
-            let tail = &mut self.1;
-            tail.insert(index - 1, element);
-            self.1 = tail.clone();
+            self.1.insert(index - 1, element);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,14 +333,7 @@ impl<T> NonEmpty<T> {
     where
         T: Ord,
     {
-        if x == &self.0 {
-            Ok(0)
-        } else {
-            self.1
-                .binary_search(x)
-                .map(|index| index + 1)
-                .map_err(|index| index + 1)
-        }
+        self.binary_search_by(|p| p.cmp(x))
     }
 
     /// Binary searches this sorted slice with a comparator function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,52 @@ impl<T> NonEmpty<T> {
     {
         NonEmpty(f(&self.0), self.1.iter().map(f).collect())
     }
+
+    /// Binary searches this sorted slice for a given element.
+    ///
+    /// If the value is found then Result::Ok is returned, containing the index of the matching element.
+    /// If there are multiple matches, then any one of the matches could be returned.
+    ///
+    /// If the value is not found then Result::Err is returned, containing the index where a
+    /// matching element could be inserted while maintaining sorted order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nonempty::NonEmpty;
+    ///
+    /// let non_empty = NonEmpty::from((0, vec![1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]));
+    /// assert_eq!(non_empty.binary_search(&13),  Ok(9));
+    /// assert_eq!(non_empty.binary_search(&4),   Err(7));
+    /// assert_eq!(non_empty.binary_search(&100), Err(13));
+    /// let r = non_empty.binary_search(&1);
+    /// assert!(match r { Ok(1..=4) => true, _ => false, });
+    /// ```
+    ///
+    /// If you want to insert an item to a sorted non-empty vector, while maintaining sort order:
+    ///
+    /// ```
+    /// use nonempty::NonEmpty;
+    ///
+    /// let mut non_empty = NonEmpty::from((0, vec![1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]));
+    /// let num = 42;
+    /// let idx = non_empty.binary_search(&num).unwrap_or_else(|x| x);
+    /// non_empty.insert(idx, num);
+    /// assert_eq!(non_empty, NonEmpty::from((0, vec![1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 42, 55])));
+    /// ```
+    pub fn binary_search(&self, x: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
+        if x == &self.0 {
+            Ok(0)
+        } else {
+            self.1
+                .binary_search(x)
+                .map(|index| index + 1)
+                .map_err(|index| index + 1)
+        }
+    }
 }
 
 impl<T> Into<Vec<T>> for NonEmpty<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,46 @@ impl<T> NonEmpty<T> {
                 .map_err(|index| index + 1),
         }
     }
+
+    /// Binary searches this sorted slice with a comparator function.
+    ///
+    /// The comparator function should implement an order consistent with the sort order of the
+    /// underlying slice, returning an order code that indicates whether its argument is Less,
+    /// Equal or Greater the desired target.
+    ///
+    /// If the value is found then Result::Ok is returned, containing the index of the matching
+    /// element. If there are multiple matches, then any one of the matches could be returned. If
+    /// the value is not found then Result::Err is returned, containing the index where a matching
+    /// element could be inserted while maintaining sorted order.
+    ///
+    /// # Examples
+    ///
+    /// Looks up a series of four elements. The first is found, with a uniquely determined
+    /// position; the second and third are not found; the fourth could match any position in [1,
+    /// 4].
+    ///
+    /// ```
+    /// use nonempty::NonEmpty;
+    ///
+    /// let non_empty = NonEmpty::from((0, vec![1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]));
+    ///
+    /// let seek = 13;
+    /// assert_eq!(non_empty.binary_search_by(|probe| probe.cmp(&seek)), Ok(9));
+    /// let seek = 4;
+    /// assert_eq!(non_empty.binary_search_by(|probe| probe.cmp(&seek)), Err(7));
+    /// let seek = 100;
+    /// assert_eq!(non_empty.binary_search_by(|probe| probe.cmp(&seek)), Err(13));
+    /// let seek = 1;
+    /// let r = non_empty.binary_search_by(|probe| probe.cmp(&seek));
+    /// assert!(match r { Ok(1..=4) => true, _ => false, });
+    /// ```
+    pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, mut f: F) -> Result<usize, usize>
+    where
+        B: Ord,
+        F: FnMut(&'a T) -> B,
+    {
+        self.binary_search_by(|k| f(k).cmp(b))
+    }
 }
 
 impl<T> Into<Vec<T>> for NonEmpty<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,43 @@ impl<T> NonEmpty<T> {
         self.1.pop()
     }
 
+    /// Inserts an element at position index within the vector, shifting all elements after it to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index > len.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nonempty::NonEmpty;
+    ///
+    /// let mut non_empty = NonEmpty::from((1, vec![2, 3]));
+    /// non_empty.insert(1, 4);
+    /// assert_eq!(non_empty, NonEmpty::from((1, vec![4, 2, 3])));
+    /// non_empty.insert(4, 5);
+    /// assert_eq!(non_empty, NonEmpty::from((1, vec![4, 2, 3, 5])));
+    /// ```
+    pub fn insert(&mut self, index: usize, element: T)
+    where
+        T: Clone,
+    {
+        let len = self.len();
+        assert!(index <= len);
+
+        if index == 0 {
+            let head = self.0.clone();
+            let tail = &mut self.1;
+            tail.insert(0, head);
+            self.0 = element;
+            self.1 = tail.clone();
+        } else {
+            let tail = &mut self.1;
+            tail.insert(index - 1, element);
+            self.1 = tail.clone();
+        }
+    }
+
     /// Get the length of the list.
     pub fn len(&self) -> usize {
         self.1.len() + 1


### PR DESCRIPTION
Implementations for:
* `insert`
* `binary_search`
* `binary_search_by`
* `binary_search_by_key`

Something I'm not fond of is that I needed to add `T: Clone` for `insert`. Any ideas on how to get around this? :thinking: 