### PR TITLE
Improve Ownership Ergonomics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,34 @@ impl<T> NonEmpty<T> {
             .map(|(h, t)| NonEmpty(h.clone(), t.into()))
     }
 
+    /// Often we have a `Vec` (or slice `&[T]`) but want to ensure that it is `NonEmpty` before
+    /// proceeding with a computation. Using `from_vec` will give us a proof
+    /// that we have a `NonEmpty` in the `Some` branch, otherwise it allows
+    /// the caller to handle the `None` case.
+    ///
+    /// This version will consume the `Vec` you pass in. If you would rather pass the data as a
+    /// slice then use `NonEmpty::from_slice`.
+    ///
+    /// # Example Use
+    ///
+    /// ```
+    /// use nonempty::NonEmpty;
+    ///
+    /// let non_empty_vec = NonEmpty::from_vec(vec![1, 2, 3, 4, 5]);
+    /// assert_eq!(non_empty_vec, Some(NonEmpty::from((1, vec![2, 3, 4, 5]))));
+    ///
+    /// let empty_vec: Option<NonEmpty<&u32>> = NonEmpty::from_vec(vec![]);
+    /// assert!(empty_vec.is_none());
+    /// ```
+    pub fn from_vec(mut vec: Vec<T>) -> Option<NonEmpty<T>> {
+        if vec.is_empty() {
+            None
+        } else {
+            let head = vec.remove(0);
+            Some(NonEmpty(head, vec))
+        }
+    }
+
     /// Deconstruct a `NonEmpty` into its head and tail.
     /// This operation never fails since we are guranteed
     /// to have a head element.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,6 +614,13 @@ impl<T> Into<Vec<T>> for NonEmpty<T> {
     }
 }
 
+impl<T> Into<(T, Vec<T>)> for NonEmpty<T> {
+    /// Turns a non-empty list into a Vec.
+    fn into(self) -> (T, Vec<T>) {
+        (self.0, self.1)
+    }
+}
+
 impl<T> From<(T, Vec<T>)> for NonEmpty<T> {
     /// Turns a pair of an element and a Vec into
     /// a NonEmpty.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,11 +334,11 @@ impl<T> NonEmpty<T> {
     ///
     /// assert_eq!(squares, expected);
     /// ```
-    pub fn map<U, F>(&self, f: F) -> NonEmpty<U>
+    pub fn map<U, F>(self, mut f: F) -> NonEmpty<U>
     where
-        F: Fn(&T) -> U,
+        F: FnMut(T) -> U,
     {
-        NonEmpty(f(&self.0), self.1.iter().map(f).collect())
+        NonEmpty(f(self.0), self.1.into_iter().map(f).collect())
     }
 
     /// Binary searches this sorted non-empty vector for a given element.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@ impl<T> NonEmpty<T> {
     /// If the value is found then Result::Ok is returned, containing the index of the matching element.
     /// If there are multiple matches, then any one of the matches could be returned.
     /// If the value is not found then Result::Err is returned, containing the index where a matching element could be
-    ///	inserted while maintaining sorted order.
+    /// inserted while maintaining sorted order.
     ///
     /// # Examples
     ///
@@ -607,17 +607,17 @@ impl<T> NonEmpty<T> {
     }
 }
 
-impl<T> Into<Vec<T>> for NonEmpty<T> {
+impl<T> From<NonEmpty<T>> for Vec<T> {
     /// Turns a non-empty list into a Vec.
-    fn into(self) -> Vec<T> {
-        iter::once(self.0).chain(self.1).collect()
+    fn from(nonempty: NonEmpty<T>) -> Vec<T> {
+        iter::once(nonempty.0).chain(nonempty.1).collect()
     }
 }
 
-impl<T> Into<(T, Vec<T>)> for NonEmpty<T> {
+impl<T> From<NonEmpty<T>> for (T, Vec<T>) {
     /// Turns a non-empty list into a Vec.
-    fn into(self) -> (T, Vec<T>) {
-        (self.0, self.1)
+    fn from(nonempty: NonEmpty<T>) -> (T, Vec<T>) {
+        (nonempty.0, nonempty.1)
     }
 }
 


### PR DESCRIPTION
* `from_vec` if we want to convert a `Vec` to a `NonEmpty` without the use of `Clone`.
* `map` should own its argument since we're outputting a new `NonEmpty<U>`
* `From` impls for `Vec` and tuple