### PR TITLE
V0.6.0 + Vec Serde

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jobs:
   fast_finish: true
 cache: cargo
 script:
-  - cargo test
+  - cargo test --features serialize

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nonempty"
-version = "0.5.0"
+version = "0.6.0"
 description = "Correct by construction non-empty vector"
 authors = ["Alexis Sellier <self@cloudhead.io>"]
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -747,13 +747,13 @@ pub mod serialize {
 
     #[derive(Debug)]
     pub enum Error {
-        EmptyVec,
+        Empty,
     }
 
     impl fmt::Display for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
-                Self::EmptyVec => f.write_str(
+                Self::Empty => f.write_str(
                     "the vector provided was empty, NonEmpty needs at least one element",
                 ),
             }
@@ -764,7 +764,7 @@ pub mod serialize {
         type Error = Error;
 
         fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
-            NonEmpty::from_vec(vec).ok_or(Error::EmptyVec)
+            NonEmpty::from_vec(vec).ok_or(Error::Empty)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,11 @@ use std::mem;
 use std::{iter, vec};
 
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "serialize",
+    serde(bound(serialize = "T: Clone + Serialize")),
+    serde(into = "Vec<T>", try_from = "Vec<T>")
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NonEmpty<T> {
     pub head: T,
@@ -734,6 +739,36 @@ impl<T> IntoIterator for NonEmpty<T> {
     }
 }
 
+#[cfg(feature = "serialize")]
+pub mod serialize {
+    use std::{convert::TryFrom, fmt};
+
+    use super::NonEmpty;
+
+    #[derive(Debug)]
+    pub enum Error {
+        EmptyVec,
+    }
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::EmptyVec => f.write_str(
+                    "the vector provided was empty, NonEmpty needs at least one element",
+                ),
+            }
+        }
+    }
+
+    impl<T> TryFrom<Vec<T>> for NonEmpty<T> {
+        type Error = Error;
+
+        fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
+            NonEmpty::from_vec(vec).ok_or(Error::EmptyVec)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::NonEmpty;
@@ -778,7 +813,8 @@ mod tests {
         #[test]
         fn test_simple_round_trip() -> Result<(), Box<dyn std::error::Error>> {
             // Given
-            let non_empty = NonEmpty::new(SimpleSerializable(42));
+            let mut non_empty = NonEmpty::new(SimpleSerializable(42));
+            non_empty.push(SimpleSerializable(777));
             let expected_value = non_empty.clone();
 
             // When


### PR DESCRIPTION
I believe the more common case for serializing a NonEmpty will be turning it
into a Vec like structure rather than an object. So this change goes
through Vec for Serialization and Deserialization, erroring if the Vec
is empty on upon deserializing.

/cc @U007D wanted to give you a heads up since you made the previous changes