### PR TITLE
cargo: add repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "Correct by construction non-empty vector"
 authors = ["Alexis Sellier <self@cloudhead.io>"]
 edition = "2018"
 license = "MIT"
+repository = "https://github.com/cloudhead/nonempty"
 
 [dependencies]
 serde = { features = ["serde_derive"], optional = true, version = "1" }


### PR DESCRIPTION
This adds the GitHub repository URL to cargo manifest, so that crates.io
and docs.rs can provide a direct link to the source code.

Closes: https://github.com/cloudhead/nonempty/issues/27