### PR TITLE
implement DoubleEndedIterator, ExactSizeIterator, and FusedIterator for the return value of NonEmpty::iter()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,12 +118,12 @@ pub struct NonEmpty<T> {
     pub tail: Vec<T>,
 }
 
-pub struct NonEmptyIter<'a, T> {
+pub struct Iter<'a, T> {
     head: Option<&'a T>,
     tail: &'a [T],
 }
 
-impl<'a, T> Iterator for NonEmptyIter<'a, T> {
+impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -138,7 +138,7 @@ impl<'a, T> Iterator for NonEmptyIter<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for NonEmptyIter<'a, T> {
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if let Some((last, rest)) = self.tail.split_last() {
             self.tail = rest;
@@ -151,13 +151,13 @@ impl<'a, T> DoubleEndedIterator for NonEmptyIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for NonEmptyIter<'a, T> {
+impl<'a, T> ExactSizeIterator for Iter<'a, T> {
     fn len(&self) -> usize {
         self.tail.len() + self.head.map_or(0, |_| 1)
     }
 }
 
-impl<'a, T> core::iter::FusedIterator for NonEmptyIter<'a, T> {}
+impl<'a, T> core::iter::FusedIterator for Iter<'a, T> {}
 
 impl<T> NonEmpty<T> {
     /// Alias for [`NonEmpty::singleton`].
@@ -340,8 +340,8 @@ impl<T> NonEmpty<T> {
     /// assert_eq!(l_iter.next(), Some(&58));
     /// assert_eq!(l_iter.next(), None);
     /// ```
-    pub fn iter(&self) -> NonEmptyIter<T> {
-        NonEmptyIter {
+    pub fn iter(&self) -> Iter<T> {
+        Iter {
             head: Some(&self.head),
             tail: &self.tail,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ impl<'a, T> DoubleEndedIterator for NonEmptyIter<'a, T> {
 
 impl<'a, T> ExactSizeIterator for NonEmptyIter<'a, T> {
     fn len(&self) -> usize {
-        self.tail.len() + if self.head.is_some() { 1 } else { 0}
+        self.tail.len() + self.head.map_or(0, |_| 1)
     }
 }
 
@@ -340,10 +340,10 @@ impl<T> NonEmpty<T> {
     /// assert_eq!(l_iter.next(), Some(&58));
     /// assert_eq!(l_iter.next(), None);
     /// ```
-    pub fn iter<'a>(&'a self) -> NonEmptyIter<'a, T> {
+    pub fn iter(&self) -> NonEmptyIter<T> {
         NonEmptyIter {
             head: Some(&self.head),
-            tail: &self.tail
+            tail: &self.tail,
         }
     }
 
@@ -766,9 +766,9 @@ impl<T> NonEmpty<T> {
     {
         let mut max = &self.head;
         for i in self.tail.iter() {
-            max = match compare(&max, &i) {
+            max = match compare(max, i) {
                 Ordering::Equal => max,
-                Ordering::Less => &i,
+                Ordering::Less => i,
                 Ordering::Greater => max,
             };
         }
@@ -977,8 +977,14 @@ mod tests {
     #[test]
     fn test_iter_both_directions() {
         let nonempty = NonEmpty::from((0, vec![1, 2, 3]));
-        assert_eq!(nonempty.iter().cloned().collect::<Vec<_>>(), vec![0, 1, 2, 3]);
-        assert_eq!(nonempty.iter().rev().cloned().collect::<Vec<_>>(), vec![3, 2, 1, 0]);
+        assert_eq!(
+            nonempty.iter().cloned().collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
+        assert_eq!(
+            nonempty.iter().rev().cloned().collect::<Vec<_>>(),
+            vec![3, 2, 1, 0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
I tried to do this for `iter_mut` too, but it's, um, a bit more complicated.

Fixes #37 