### PR TITLE
More generic minimum_by, minimum_by_key, maximum_by, and maximum_by_key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1094,6 +1094,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_nontrivial_minimum_by_key() {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        struct Position {
+            x: i32,
+            y: i32,
+        }
+        impl Position {
+            pub fn distance_squared(&self, other: Position) -> u32 {
+                let dx = self.x - other.x;
+                let dy = self.y - other.y;
+                (dx * dx + dy * dy) as u32
+            }
+        }
+        let positions = nonempty![
+            Position { x: 1, y: 1 },
+            Position { x: 0, y: 0 },
+            Position { x: 3, y: 4 }
+        ];
+        let target = Position { x: 1, y: 2 };
+        let closest = positions.minimum_by_key(|position| position.distance_squared(target));
+        assert_eq!(closest, &Position { x: 1, y: 1 });
+    }
+
     #[cfg(feature = "serialize")]
     mod serialize {
         use crate::NonEmpty;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -806,9 +806,9 @@ impl<T> NonEmpty<T> {
     /// let non_empty = NonEmpty::from(((2, 1), vec![(2, -34), (4, 42), (0, 76), (1, 4), (3, 5)]));
     /// assert_eq!(non_empty.maximum_by(|(k, _), (l, _)| k.cmp(l)), &(4, 42));
     /// ```
-    pub fn maximum_by<F>(&self, compare: F) -> &T
+    pub fn maximum_by<'a, F>(&'a self, mut compare: F) -> &T
     where
-        F: Fn(&T, &T) -> Ordering,
+        F: FnMut(&'a T, &'a T) -> Ordering,
     {
         let mut max = &self.head;
         for i in self.tail.iter() {
@@ -834,9 +834,9 @@ impl<T> NonEmpty<T> {
     /// let non_empty = NonEmpty::from(((2, 1), vec![(2, -34), (4, 42), (0, 76), (1, 4), (3, 5)]));
     /// assert_eq!(non_empty.minimum_by(|(k, _), (l, _)| k.cmp(l)), &(0, 76));
     /// ```
-    pub fn minimum_by<F>(&self, compare: F) -> &T
+    pub fn minimum_by<'a, F>(&'a self, mut compare: F) -> &T
     where
-        F: Fn(&T, &T) -> Ordering,
+        F: FnMut(&'a T, &'a T) -> Ordering,
     {
         self.maximum_by(|a, b| compare(a, b).reverse())
     }
@@ -856,12 +856,12 @@ impl<T> NonEmpty<T> {
     /// let non_empty = NonEmpty::from(((2, 1), vec![(2, -34), (4, 42), (0, 76), (1, 4), (3, 5)]));
     /// assert_eq!(non_empty.maximum_by_key(|(k, _)| k), &(4, 42));
     /// ```
-    pub fn maximum_by_key<U, F>(&self, f: F) -> &T
+    pub fn maximum_by_key<'a, U, F>(&'a self, mut f: F) -> &T
     where
         U: Ord,
-        F: Fn(&T) -> &U,
+        F: FnMut(&'a T) -> U,
     {
-        self.maximum_by(|i, j| f(i).cmp(f(j)))
+        self.maximum_by(|i, j| f(i).cmp(&f(j)))
     }
 
     /// Returns the element that gives the minimum value with respect to the specified function.
@@ -879,12 +879,12 @@ impl<T> NonEmpty<T> {
     /// let non_empty = NonEmpty::from(((2, 1), vec![(2, -34), (4, 42), (0, 76), (1, 4), (3, 5)]));
     /// assert_eq!(non_empty.minimum_by_key(|(k, _)| k), &(0, 76));
     /// ```
-    pub fn minimum_by_key<U, F>(&self, f: F) -> &T
+    pub fn minimum_by_key<'a, U, F>(&'a self, mut f: F) -> &T
     where
         U: Ord,
-        F: Fn(&T) -> &U,
+        F: FnMut(&'a T) -> U,
     {
-        self.minimum_by(|i, j| f(i).cmp(f(j)))
+        self.minimum_by(|i, j| f(i).cmp(&f(j)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -855,6 +855,7 @@ impl<T> NonEmpty<T> {
     ///
     /// let non_empty = NonEmpty::from(((2, 1), vec![(2, -34), (4, 42), (0, 76), (1, 4), (3, 5)]));
     /// assert_eq!(non_empty.maximum_by_key(|(k, _)| k), &(4, 42));
+    /// assert_eq!(non_empty.maximum_by_key(|(k, _)| -k), &(0, 76));
     /// ```
     pub fn maximum_by_key<'a, U, F>(&'a self, mut f: F) -> &T
     where
@@ -878,6 +879,7 @@ impl<T> NonEmpty<T> {
     ///
     /// let non_empty = NonEmpty::from(((2, 1), vec![(2, -34), (4, 42), (0, 76), (1, 4), (3, 5)]));
     /// assert_eq!(non_empty.minimum_by_key(|(k, _)| k), &(0, 76));
+    /// assert_eq!(non_empty.minimum_by_key(|(k, _)| -k), &(4, 42));
     /// ```
     pub fn minimum_by_key<'a, U, F>(&'a self, mut f: F) -> &T
     where


### PR DESCRIPTION
As shown in the additional tests, I wanted to be able to call maximum_by_key and minimum_by_key with a function that returns an owned value (and not a reference). This would also be more in line with https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.min_by_key.
```rust
let non_empty = NonEmpty::from(((2, 1), vec![(2, -34), (4, 42), (0, 76), (1, 4), (3, 5)]));
assert_eq!(non_empty.maximum_by_key(|(k, _)| -k), &(0, 76));
```
Obviously I could replace maximum_by_key of -k with minimum_by_key, so there's also a more nontrivial example:

```rust
#[test]
fn test_nontrivial_minimum_by_key() {
    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
    struct Position {
        x: i32,
        y: i32,
    }
    impl Position {
        pub fn distance_squared(&self, other: Position) -> u32 {
            let dx = self.x - other.x;
            let dy = self.y - other.y;
            (dx * dx + dy * dy) as u32
        }
    }
    let positions = nonempty![
        Position { x: 1, y: 1 },
        Position { x: 0, y: 0 },
        Position { x: 3, y: 4 }
    ];
    let target = Position { x: 1, y: 2 };
    let closest = positions.minimum_by_key(|position| position.distance_squared(target));
    assert_eq!(closest, &Position { x: 1, y: 1 });
}
```