### PR TITLE
Fix macro to accept trailing comma

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,16 @@ pub mod nonzero;
 /// let v = nonempty![1];
 /// assert_eq!(v, NonEmpty { head: 1, tail: Vec::new() });
 ///
+/// // Accepts trailing commas
+/// let v = nonempty![1,];
+/// assert_eq!(v, NonEmpty { head: 1, tail: Vec::new() });
+///
 /// // Doesn't compile!
 /// // let v = nonempty![];
 /// ```
 #[macro_export]
 macro_rules! nonempty {
-    ($h:expr, $( $x:expr ),*) => {{
+    ($h:expr, $( $x:expr ),* $(,)?) => {{
         let tail = vec![$($x),*];
         $crate::NonEmpty { head: $h, tail }
     }};


### PR DESCRIPTION
If the `nonempty!` macro was used with a trailing comma:

    let v = nonempty![1,];

then it would fail to compile due to the trailing comma.

The `vec!` macro[[0]] uses `$(,)?` to handle this case:

    ($($x:expr),+ $(,)?)

To fix the `nonempty!` macro, the same is done and a test case is added to its documentation.

[0]: https://doc.rust-lang.org/src/alloc/macros.rs.html#49


Fixes #43 