### PR TITLE
feat: add NonEmpty::as_ref that converts from &NonEmpty<T> to NonEmpty<&T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,14 @@ impl<T> NonEmpty<T> {
         Self::singleton(e)
     }
 
+    /// Converts from &NonEmpty<T> to NonEmpty<&T>.
+    pub fn as_ref(&self) -> NonEmpty<&T> {
+        NonEmpty {
+            head: &self.head,
+            tail: self.tail.iter().collect(),
+        }
+    }
+
     /// Attempt to convert an iterator into a `NonEmpty` vector.
     /// Returns `None` if the iterator was empty.
     pub fn collect<I>(iter: I) -> Option<NonEmpty<T>>


### PR DESCRIPTION
Similar to [`Option::as_ref`](https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.as_ref)

This is helpful to use `NonEmpty::map` without cloning when there's only &NonEmpty<T> being available

```rust
fn foo(a: &NonEmpty<Bar>) {
    // Instead of
    a.clone().map(...)
    // Now we can do
    a.as_ref().map(...)
}
```