### PR TITLE
Add a `bincode2` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,12 @@ repository = "https://github.com/cloudhead/nonempty"
 [dependencies]
 serde = { features = ["serde_derive"], optional = true, version = "1" }
 arbitrary = { features = ["derive"], optional = true, version = "1" }
+bincode = { optional = true, version = "2.0.0-rc.3" }
 
 [features]
 serialize = ["serde"]
 arbitrary = ["dep:arbitrary"]
+bincode2 = ["dep:bincode"]
 
 [dev-dependencies]
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,11 @@
 //!
 //! * `serialize`: `serde` support.
 //! * `arbitrary`: `arbitrary` support.
+//! * `bincode2`" `bincode@2.0.0-rc.3` support.
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+#[cfg(feature = "bincode2")]
+use bincode::{Decode, Encode};
 #[cfg(feature = "serialize")]
 use serde::{
     ser::{SerializeSeq, Serializer},
@@ -121,7 +124,12 @@ macro_rules! nonempty {
 /// Non-empty vector.
 #[cfg_attr(feature = "serialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "bincode2", derive(Encode, Decode))]
 #[cfg_attr(feature = "serialize", serde(try_from = "Vec<T>"))]
+#[cfg_attr(feature = "bincode2", bincode(
+    encode_bounds = "T: Encode + 'static",
+    decode_bounds = "T: Decode + 'static",
+))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NonEmpty<T> {
     pub head: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,10 +126,13 @@ macro_rules! nonempty {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "bincode2", derive(Encode, Decode))]
 #[cfg_attr(feature = "serialize", serde(try_from = "Vec<T>"))]
-#[cfg_attr(feature = "bincode2", bincode(
-    encode_bounds = "T: Encode + 'static",
-    decode_bounds = "T: Decode + 'static",
-))]
+#[cfg_attr(
+    feature = "bincode2",
+    bincode(
+        encode_bounds = "T: Encode + 'static",
+        decode_bounds = "T: Decode + 'static",
+    )
+)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NonEmpty<T> {
     pub head: T,


### PR DESCRIPTION
This adds a new `bincode2` feature which when enabled derives `bincode::Encode` and `bincode::Decode` (from `bincode@2.0.0-rc.3`) for `NonEmpty<T>`.

The goal of this is to avoid having to use `#[bincode(with_serde)]` when having a field containing `NonEmpty<T>`.