### PR TITLE
Enable `no_std` use via the addition of a default-enabled feature flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `std` feature flag; building with `--no-default-features` now enables `no_std` use.
+
+### Changed
+- MSRV is now 1.56 (this is a semver-breaking change)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,18 @@ name = "nonempty"
 version = "0.10.0"
 description = "Correct by construction non-empty vector"
 authors = ["Alexis Sellier <self@cloudhead.io>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 repository = "https://github.com/cloudhead/nonempty"
 
 [dependencies]
-serde = { features = ["serde_derive"], optional = true, version = "1" }
+serde = { features = ["derive", "alloc"], default-features = false, optional = true, version = "1" }
 arbitrary = { features = ["derive"], optional = true, version = "1" }
 
 [features]
-serialize = ["serde"]
+default = ["std"]
+std = []
+serialize = ["dep:serde"]
 arbitrary = ["dep:arbitrary"]
 
 [dev-dependencies]

--- a/src/nonzero.rs
+++ b/src/nonzero.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 /// A non-empty list which statically guarantees certain operations
-/// cannot return zero, using [`std::num::NonZeroUsize`].
+/// cannot return zero, using [`core::num::NonZeroUsize`].
 ///
 /// *Experimental*
 ///
@@ -35,7 +35,7 @@ impl<T> From<super::NonEmpty<T>> for NonEmpty<T> {
     }
 }
 
-impl<T> std::ops::Deref for NonEmpty<T> {
+impl<T> core::ops::Deref for NonEmpty<T> {
     type Target = super::NonEmpty<T>;
 
     fn deref(&self) -> &Self::Target {
@@ -43,7 +43,7 @@ impl<T> std::ops::Deref for NonEmpty<T> {
     }
 }
 
-impl<T> std::ops::DerefMut for NonEmpty<T> {
+impl<T> core::ops::DerefMut for NonEmpty<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -54,7 +54,7 @@ mod tests {
     use crate::nonzero;
     use crate::NonEmpty;
 
-    use std::convert::TryInto;
+    use core::convert::TryInto;
 
     #[test]
     fn test_nonzero() {
@@ -69,7 +69,7 @@ mod tests {
         use crate::nonzero;
         use arbitrary::{Arbitrary, Unstructured};
 
-        use std::convert::TryInto;
+        use core::convert::TryInto;
 
         #[test]
         fn test_nonzero_arbitrary_empty_tail() -> arbitrary::Result<()> {


### PR DESCRIPTION
This allows users who specify `nonempty` as a `--no-default-features` dependency can use the crate in environments where `alloc` is available but `std` is not, such as embedded device firmware.

This requires `edition = 2021`, which implies a change to an MSRV of 1.56, therefor , will require a semver bump for release.