### PR TITLE
Use vec![] for instantiate an empty vector in nonempty! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ macro_rules! nonempty {
     ($h:expr) => {
         $crate::NonEmpty {
             head: $h,
-            tail: alloc::vec::Vec::new(),
+            tail: vec![],
         }
     };
 }


### PR DESCRIPTION
It fixes https://github.com/cloudhead/nonempty/issues/68

I hope using `vec![]` should not be a big problem, cause `vec![]` is already used in another branch of the macro.

Thank you again for you work!