### PR TITLE
Add TryFrom<Vec<T>>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1003,6 +1003,14 @@ impl<T> From<(T, Vec<T>)> for NonEmpty<T> {
     }
 }
 
+impl<T> TryFrom<Vec<T>> for NonEmpty<T> {
+    type Error = ();
+
+    fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
+        Self::from_vec(value).ok_or(())
+    }
+}
+
 impl<T> IntoIterator for NonEmpty<T> {
     type Item = T;
     type IntoIter = iter::Chain<iter::Once<T>, vec::IntoIter<Self::Item>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1235,6 +1235,15 @@ mod tests {
         assert_eq!(numbers, nonempty![1, 2, 3]);
     }
 
+    #[test]
+    fn test_try_into() {
+        assert_eq!(vec![1].try_into(), Ok(nonempty![1]));
+        assert_eq!(
+            Vec::<i32>::new().try_into() as Result<NonEmpty<i32>, ()>,
+            Err(())
+        );
+    }
+
     #[cfg(feature = "serialize")]
     mod serialize {
         use crate::NonEmpty;


### PR DESCRIPTION
Adds the convenience of being able to call 

```
...
  .try_into()?
```

And if anyone doesn't like the default error of `()` they can `.map_err(|_| MyError::NoResults)` or something like that.