### PR TITLE
Choose random element

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/cloudhead/nonempty"
 serde = { features = ["derive", "alloc"], default-features = false, optional = true, version = "1" }
 arbitrary = { features = ["derive"], optional = true, version = "1" }
 bincode = { optional = true, version = "2.0.1" }
+rand = { optional = true, version = "0.9" }
 
 [features]
 default = ["std"]
@@ -18,6 +19,7 @@ std = []
 serialize = ["dep:serde"]
 arbitrary = ["dep:arbitrary"]
 bincode = ["dep:bincode"]
+random = ["dep:rand"]
 
 [dev-dependencies]
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -971,6 +971,12 @@ impl<T> NonEmpty<T> {
             self.tail.insert(index - 1, head);
         }
     }
+
+    #[cfg(feature = "random")]
+    pub fn choose(&self, rng: &mut impl rand::Rng) -> &T {
+        let index = rng.random_range(0..self.len());
+        self.get(index).unwrap()
+    }
 }
 
 impl<T: Default> Default for NonEmpty<T> {


### PR DESCRIPTION
One of my main uses of NonEmpty is to allow selecting a random element without returning `Option<T>`. I'd like to see this feature upstreamed so I don't have to maintain a fork. I can make edits, just let e know!