### PR TITLE
clippy: missing const for fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ bincode = ["dep:bincode"]
 
 [dev-dependencies]
 serde_json = "1"
+
+[lints.clippy]
+missing_const_for_fn = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ impl<T> NonEmpty<T> {
     /// *head *= 42;
     /// assert_eq!(non_empty.first(), &42);
     /// ```
-    pub fn first_mut(&mut self) -> &mut T {
+    pub const fn first_mut(&mut self) -> &mut T {
         &mut self.head
     }
 
@@ -339,17 +339,17 @@ impl<T> NonEmpty<T> {
     }
 
     /// Get the length of the list.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.tail.len() + 1
     }
 
     /// Gets the length of the list as a NonZeroUsize.
-    pub fn len_nonzero(&self) -> NonZeroUsize {
+    pub const fn len_nonzero(&self) -> NonZeroUsize {
         unsafe { NonZeroUsize::new_unchecked(self.tail.len().saturating_add(1)) }
     }
 
     /// Get the capacity of the list.
-    pub fn capacity(&self) -> NonZeroUsize {
+    pub const fn capacity(&self) -> NonZeroUsize {
         NonZeroUsize::MIN.saturating_add(self.tail.capacity())
     }
 

--- a/src/nonzero.rs
+++ b/src/nonzero.rs
@@ -14,12 +14,12 @@ pub struct NonEmpty<T>(super::NonEmpty<T>);
 
 impl<T> NonEmpty<T> {
     /// Get the length of the list.
-    pub fn len(&self) -> NonZeroUsize {
+    pub const fn len(&self) -> NonZeroUsize {
         unsafe { NonZeroUsize::new_unchecked(self.0.tail.len() + 1) }
     }
 
     /// Get the capacity of the list.
-    pub fn capacity(&self) -> NonZeroUsize {
+    pub const fn capacity(&self) -> NonZeroUsize {
         unsafe { NonZeroUsize::new_unchecked(self.0.tail.capacity() + 1) }
     }
 


### PR DESCRIPTION
Make functions const wherever possible