### PR TITLE
Fix doc order for split: first, middle, last

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,8 +529,8 @@ impl<T> NonEmpty<T> {
         (&self.head, &self.tail)
     }
 
-    /// Deconstruct a `NonEmpty` into its first, last, and
-    /// middle elements, in that order.
+    /// Deconstruct a `NonEmpty` into its first, middle, and
+    /// last elements, in that order.
     ///
     /// If there is only one element then last is `None`.
     ///


### PR DESCRIPTION
Closes #85. The doc for `NonEmpty::split` listed the order as "first, last, and middle", but the function returns `(&T, &[T], Option<&T>)` i.e. first, middle, last. Matches the existing example.